### PR TITLE
Update the fplugin deployment

### DIFF
--- a/kubernetes/deployments/fplugin.yaml
+++ b/kubernetes/deployments/fplugin.yaml
@@ -15,15 +15,15 @@ spec:
         app: fplugin
     spec:
       containers:
-      - image: gcr.io/fantasy-218701/fplugin:4a5a837a1cc86954fc4fa09dd2d32b3eb0f185c5
-        name: fplugin
-        ports:
-        - containerPort: 8080
-          protocol: TCP
+      - image: gcr.io/fantasy-218701/fplugin-draft:60f4399f4c4eab5ecd4c9208afe3671d50c72976
         livenessProbe:
           httpGet:
             path: /alive
             port: 8080
+        name: fplugin
+        ports:
+        - containerPort: 8080
+          protocol: TCP
         readinessProbe:
           httpGet:
             path: /ready


### PR DESCRIPTION
This commit updates the fplugin deployment container image to:

    gcr.io/fantasy-218701/fplugin-draft:60f4399f4c4eab5ecd4c9208afe3671d50c72976

Build ID: cf6de261-416b-4e55-bfa3-4225b65588e0